### PR TITLE
Fixed namespaces in `Module` and `Session` classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
+# PhpStorm project files
 .idea/
+
+# Composer dependencies
+vendor/

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,18 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "ceda7bea77208383bac201801ffcab39",
+    "packages": [],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": [],
+    "plugin-api-version": "2.3.0"
+}

--- a/src/ChaCha20Params.php
+++ b/src/ChaCha20Params.php
@@ -1,9 +1,10 @@
 <?php
+
 namespace Pkcs11;
 
 class ChaCha20Params
 {
-	public function __construct(string $nonce, string $blockCounter)
-	{
-	}
+    public function __construct(string $nonce, string $blockCounter)
+    {
+    }
 }

--- a/src/DecryptionContext.php
+++ b/src/DecryptionContext.php
@@ -1,14 +1,14 @@
 <?php
+
 namespace Pkcs11;
 
 class DecryptionContext
 {
-	public function update(?string $data = null): string
-	{
-	}
+    public function finalize(): string
+    {
+    }
 
-
-	public function finalize(): string
-	{
-	}
+    public function update(?string $data = null): string
+    {
+    }
 }

--- a/src/DigestContext.php
+++ b/src/DigestContext.php
@@ -1,19 +1,18 @@
 <?php
+
 namespace Pkcs11;
 
 class DigestContext
 {
-	public function update(?string $data = null): void
-	{
-	}
+    public function finalize(): string
+    {
+    }
 
+    public function keyUpdate(?object $key = null): void
+    {
+    }
 
-	public function keyUpdate(?object $key = null): void
-	{
-	}
-
-
-	public function finalize(): string
-	{
-	}
+    public function update(?string $data = null): void
+    {
+    }
 }

--- a/src/Ecdh1DeriveParams.php
+++ b/src/Ecdh1DeriveParams.php
@@ -1,9 +1,10 @@
 <?php
+
 namespace Pkcs11;
 
 class Ecdh1DeriveParams
 {
-	public function __construct(int $kdfId, string $sharedData, string $publicData)
-	{
-	}
+    public function __construct(int $kdfId, string $sharedData, string $publicData)
+    {
+    }
 }

--- a/src/EncryptionContext.php
+++ b/src/EncryptionContext.php
@@ -1,14 +1,14 @@
 <?php
+
 namespace Pkcs11;
 
 class EncryptionContext
 {
-	public function update(?string $data = null): string
-	{
-	}
+    public function finalize(): string
+    {
+    }
 
-
-	public function finalize(): string
-	{
-	}
+    public function update(?string $data = null): string
+    {
+    }
 }

--- a/src/GcmParams.php
+++ b/src/GcmParams.php
@@ -1,9 +1,10 @@
 <?php
+
 namespace Pkcs11;
 
 class GcmParams
 {
-	public function __construct(string $iv, string $aad, int $sTagLen)
-	{
-	}
+    public function __construct(string $iv, string $aad, int $sTagLen)
+    {
+    }
 }

--- a/src/Key.php
+++ b/src/Key.php
@@ -1,69 +1,58 @@
 <?php
+
 namespace Pkcs11;
 
 class Key
 {
-	public function initializeSignature(object $mechanism): void
-	{
-	}
+    public function decrypt(object $mechanism, string $ciphertext): string
+    {
+    }
 
+    public function derive(object $mechanism, array $template): void
+    {
+    }
 
-	public function initializeVerification(object $mechanism): void
-	{
-	}
+    public function encrypt(object $mechanism, string $plaintext): string
+    {
+    }
 
+    public function getAttributeValue(array $attributeIds)
+    {
+    }
 
-	public function initializeEncryption(object $mechanism): void
-	{
-	}
+    public function getSize()
+    {
+    }
 
+    public function initializeDecryption(object $mechanism): void
+    {
+    }
 
-	public function initializeDecryption(object $mechanism): void
-	{
-	}
+    public function initializeEncryption(object $mechanism): void
+    {
+    }
 
+    public function initializeSignature(object $mechanism): void
+    {
+    }
 
-	public function encrypt(object $mechanism, string $plaintext): string
-	{
-	}
+    public function initializeVerification(object $mechanism): void
+    {
+    }
 
+    public function sign(object $mechanism, string $data): string
+    {
+    }
 
-	public function decrypt(object $mechanism, string $ciphertext): string
-	{
-	}
+    public function unwrap(object $mechanism, string $ciphertext, array $template): void
+    {
+    }
 
+    public function verify(object $mechanism, string $data, string $signature): bool
+    {
+    }
 
-	public function wrap(object $mechanism, object $key): string
-	{
-	}
-
-
-	public function unwrap(object $mechanism, string $ciphertext, array $template): void
-	{
-	}
-
-
-	public function sign(object $mechanism, string $data): string
-	{
-	}
-
-
-	public function verify(object $mechanism, string $data, string $signature): bool
-	{
-	}
-
-
-	public function derive(object $mechanism, array $template): void
-	{
-	}
-
-
-	public function getAttributeValue(array $attributeIds)
-	{
-	}
-
-
-	public function getSize()
-	{
-	}
+    public function wrap(object $mechanism, object $key): string
+    {
+    }
 }

--- a/src/KeyPair.php
+++ b/src/KeyPair.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Pkcs11;
 
 class KeyPair

--- a/src/Mechanism.php
+++ b/src/Mechanism.php
@@ -1,14 +1,15 @@
 <?php
+
 namespace Pkcs11;
 
 class Mechanism
 {
-	public function __construct(int $mechanismId, $mechanismArgument = null)
-	{
-	}
+    public function __construct(int $mechanismId, $mechanismArgument = null)
+    {
+    }
 
 
-	public function __debugInfo(): array
-	{
-	}
+    public function __debugInfo(): array
+    {
+    }
 }

--- a/src/Module.php
+++ b/src/Module.php
@@ -1,299 +1,247 @@
 <?php
+
 namespace Pkcs11;
 
 class Module
 {
-	public function __construct(string $modulePath)
-	{
-	}
-
-
-	public function getInfo(): array
-	{
-	}
-
-
-	public function getSlots(): array
-	{
-	}
-
-
-	public function getSlotList(): array
-	{
-	}
-
-
-	public function getSlotInfo(int $slotId): array
-	{
-	}
-
-
-	public function getTokenInfo(int $slotId): array
-	{
-	}
-
-
-	public function getMechanismList(int $slotId): array
-	{
-	}
-
-
-	public function getMechanismInfo(int $slotId, int $mechanismId): array
-	{
-	}
-
-
-	public function initToken(int $slotid, string $label, string $sopin)
-	{
-	}
-
-
-	public function openSession(
-		int $slotid,
-		int $flags,
-		?string $application = null,
-		?callable $notify = null,
-	): \Pkcs11\Session
-	{
-	}
-
-
-	public function waitForSlotEvent(?int $php_flags = null)
-	{
-	}
-
-
-	public function C_GetInfo(?array $pInfo = null): array
-	{
-	}
-
-
-	public function C_GetSlotList(bool $tokenPresent, ?array $pSlotList = null): array
-	{
-	}
-
-
-	public function C_GetSlotInfo(int $slotId, ?array $pInfo = null)
-	{
-	}
-
-
-	public function C_GetTokenInfo(int $slotId, ?array $pInfo = null)
-	{
-	}
-
-
-	public function C_GetMechanismList(int $slotId, ?array $pMechanismList = null): array
-	{
-	}
-
-
-	public function C_GetMechanismInfo(int $slotId, int $type, ?array $pInfo = null)
-	{
-	}
-
-
-	public function C_InitToken(int $slotid, string $label, string $sopin)
-	{
-	}
-
-
-	public function C_SetPIN(Pkcs11\Session $session, string $oldPin, string $newPin)
-	{
-	}
-
-
-	public function C_InitPIN(Pkcs11\Session $session, string $newPin)
-	{
-	}
-
-
-	public function C_OpenSession(
-		int $slotID,
-		int $flags,
-		?string $pApplication = null,
-		?callable $notify = null,
-		?Pkcs11\Session $hSession = null,
-	): \Pkcs11\Session
-	{
-	}
-
-
-	public function C_CloseSession(Pkcs11\Session $session)
-	{
-	}
-
-
-	public function C_GetSessionInfo(Pkcs11\Session $session, ?array $pInfo = null)
-	{
-	}
-
-
-	public function C_Login(Pkcs11\Session $session, int $loginType, string $pin)
-	{
-	}
-
-
-	public function C_Logout(Pkcs11\Session $session)
-	{
-	}
-
-
-	public function C_WaitForSlotEvent(?int $php_flags = null, ?int $php_slotID = null)
-	{
-	}
-
-
-	public function C_GenerateKey(
-		Pkcs11\Session $session,
-		Pkcs11\Mechanism $mechanism,
-		array $template,
-		?IS_LONG $phKey = null,
-	) {
-	}
-
-
-	public function C_GenerateKeyPair(
-		Pkcs11\Session $session,
-		Pkcs11\Mechanism $mechanism,
-		array $pkTemplate,
-		array $skTemplate,
-		?Pkcs11\Key $phPublicKey = null,
-		?Pkcs11\Key $phPrivateKey = null,
-	) {
-	}
-
-
-	public function C_DigestInit(Pkcs11\Session $session, Pkcs11\Mechanism $mechanism)
-	{
-	}
-
-
-	public function C_Digest(Pkcs11\Session $session, string $data, ?string $digest = null)
-	{
-	}
-
-
-	public function C_DigestUpdate(Pkcs11\Session $session, string $part)
-	{
-	}
-
-
-	public function C_DigestKey(Pkcs11\Session $session, Pkcs11\Key $key)
-	{
-	}
-
-
-	public function C_DigestFinal(Pkcs11\Session $session, ?string $digest = null)
-	{
-	}
-
-
-	public function C_SignInit(Pkcs11\Session $session, Pkcs11\Mechanism $mechanism, int $key)
-	{
-	}
-
-
-	public function C_Sign(Pkcs11\Session $session, string $data, ?string $signature = null)
-	{
-	}
-
-
-	public function C_VerifyInit(Pkcs11\Session $session, Pkcs11\Mechanism $mechanism, int $key)
-	{
-	}
-
-
-	public function C_Verify(Pkcs11\Session $session, string $data, string $signature)
-	{
-	}
-
-
-	public function C_EncryptInit(Pkcs11\Session $session, Pkcs11\Mechanism $mechanism, int $key)
-	{
-	}
-
-
-	public function C_Encrypt(Pkcs11\Session $session, string $data, ?string $encryptedData = null)
-	{
-	}
-
-
-	public function C_DecryptInit(Pkcs11\Session $session, Pkcs11\Mechanism $mechanism, int $key)
-	{
-	}
-
-
-	public function C_Decrypt(Pkcs11\Session $session, string $encryptedData, ?string $data = null)
-	{
-	}
-
-
-	public function C_Wrap(
-		Pkcs11\Session $session,
-		Pkcs11\Mechanism $mechanism,
-		int $keyId,
-		int $targetKeyId,
-		?string $ciphertext = null,
-	) {
-	}
-
-
-	public function C_Unwrap(
-		Pkcs11\Session $session,
-		Pkcs11\Mechanism $mechanism,
-		?int $keyId = null,
-		string $encryptedData,
-		array $template,
-	) {
-	}
-
-
-	public function C_GenerateRandom(Pkcs11\Session $session, int $RandomLen, ?string $pRandomData = null)
-	{
-	}
-
-
-	public function C_SeedRandom(Pkcs11\Session $session, string $Seed)
-	{
-	}
-
-
-	public function C_CreateObject(Pkcs11\Session $session, array $template, ?Pkcs11\P11Object $phObject = null)
-	{
-	}
-
-
-	public function C_FindObjectsInit(Pkcs11\Session $session, array $template)
-	{
-	}
-
-
-	public function C_FindObjects(Pkcs11\Session $session, ?array $Objects = null, int $MaxObjectCount)
-	{
-	}
-
-
-	public function C_FindObjectsFinal(Pkcs11\Session $session)
-	{
-	}
-
-
-	public function C_GetAttributeValue(Pkcs11\Session $session, int $object, array $template)
-	{
-	}
-
-
-	public function C_CopyObject(
-		Pkcs11\Session $session,
-		Pkcs11\P11Object $object,
-		array $template,
-		?Pkcs11\P11Object $phNewObject = null,
-	) {
-	}
-
-
-	public function C_DestroyObject(Pkcs11\Session $session, Pkcs11\P11Object $object)
-	{
-	}
+    public function __construct(string $modulePath)
+    {
+    }
+
+    public function C_CloseSession(Session $session)
+    {
+    }
+
+    public function C_CopyObject(
+        Session $session,
+        P11Object $object,
+        array $template,
+        ?P11Object $phNewObject = null,
+    ) {
+    }
+
+    public function C_CreateObject(Session $session, array $template, ?P11Object $phObject = null)
+    {
+    }
+
+    public function C_Decrypt(Session $session, string $encryptedData, ?string $data = null)
+    {
+    }
+
+    public function C_DecryptInit(Session $session, Mechanism $mechanism, int $key)
+    {
+    }
+
+    public function C_DestroyObject(Session $session, P11Object $object)
+    {
+    }
+
+    public function C_Digest(Session $session, string $data, ?string $digest = null)
+    {
+    }
+
+    public function C_DigestFinal(Session $session, ?string $digest = null)
+    {
+    }
+
+    public function C_DigestInit(Session $session, Mechanism $mechanism)
+    {
+    }
+
+    public function C_DigestKey(Session $session, Key $key)
+    {
+    }
+
+    public function C_DigestUpdate(Session $session, string $part)
+    {
+    }
+
+    public function C_Encrypt(Session $session, string $data, ?string $encryptedData = null)
+    {
+    }
+
+    public function C_EncryptInit(Session $session, Mechanism $mechanism, int $key)
+    {
+    }
+
+    public function C_FindObjects(Session $session, ?array $Objects = null, int $MaxObjectCount)
+    {
+    }
+
+    public function C_FindObjectsFinal(Session $session)
+    {
+    }
+
+    public function C_FindObjectsInit(Session $session, array $template)
+    {
+    }
+
+    public function C_GenerateKey(
+        Session $session,
+        Mechanism $mechanism,
+        array $template,
+        ?IS_LONG $phKey = null,
+    ) {
+    }
+
+    public function C_GenerateKeyPair(
+        Session $session,
+        Mechanism $mechanism,
+        array $pkTemplate,
+        array $skTemplate,
+        ?Key $phPublicKey = null,
+        ?Key $phPrivateKey = null,
+    ) {
+    }
+
+    public function C_GenerateRandom(Session $session, int $RandomLen, ?string $pRandomData = null)
+    {
+    }
+
+    public function C_GetAttributeValue(Session $session, int $object, array $template)
+    {
+    }
+
+    public function C_GetInfo(?array $pInfo = null): array
+    {
+    }
+
+    public function C_GetMechanismInfo(int $slotId, int $type, ?array $pInfo = null)
+    {
+    }
+
+    public function C_GetMechanismList(int $slotId, ?array $pMechanismList = null): array
+    {
+    }
+
+    public function C_GetSessionInfo(Session $session, ?array $pInfo = null)
+    {
+    }
+
+    public function C_GetSlotInfo(int $slotId, ?array $pInfo = null)
+    {
+    }
+
+    public function C_GetSlotList(bool $tokenPresent, ?array $pSlotList = null): array
+    {
+    }
+
+    public function C_GetTokenInfo(int $slotId, ?array $pInfo = null)
+    {
+    }
+
+    public function C_InitPIN(Session $session, string $newPin)
+    {
+    }
+
+    public function C_InitToken(int $slotid, string $label, string $sopin)
+    {
+    }
+
+    public function C_Login(Session $session, int $loginType, string $pin)
+    {
+    }
+
+    public function C_Logout(Session $session)
+    {
+    }
+
+    public function C_OpenSession(
+        int $slotID,
+        int $flags,
+        ?string $pApplication = null,
+        ?callable $notify = null,
+        ?Session $hSession = null,
+    ): Session {
+    }
+
+    public function C_SeedRandom(Session $session, string $Seed)
+    {
+    }
+
+    public function C_SetPIN(Session $session, string $oldPin, string $newPin)
+    {
+    }
+
+    public function C_Sign(Session $session, string $data, ?string $signature = null)
+    {
+    }
+
+    public function C_SignInit(Session $session, Mechanism $mechanism, int $key)
+    {
+    }
+
+    public function C_Unwrap(
+        Session $session,
+        Mechanism $mechanism,
+        ?int $keyId = null,
+        string $encryptedData,
+        array $template,
+    ) {
+    }
+
+    public function C_Verify(Session $session, string $data, string $signature)
+    {
+    }
+
+    public function C_VerifyInit(Session $session, Mechanism $mechanism, int $key)
+    {
+    }
+
+    public function C_WaitForSlotEvent(?int $php_flags = null, ?int $php_slotID = null)
+    {
+    }
+
+    public function C_Wrap(
+        Session $session,
+        Mechanism $mechanism,
+        int $keyId,
+        int $targetKeyId,
+        ?string $ciphertext = null,
+    ) {
+    }
+
+    public function getInfo(): array
+    {
+    }
+
+    public function getMechanismInfo(int $slotId, int $mechanismId): array
+    {
+    }
+
+    public function getMechanismList(int $slotId): array
+    {
+    }
+
+    public function getSlotInfo(int $slotId): array
+    {
+    }
+
+    public function getSlotList(): array
+    {
+    }
+
+    public function getSlots(): array
+    {
+    }
+
+    public function getTokenInfo(int $slotId): array
+    {
+    }
+
+    public function initToken(int $slotid, string $label, string $sopin)
+    {
+    }
+
+    public function openSession(
+        int $slotid,
+        int $flags,
+        ?string $application = null,
+        ?callable $notify = null,
+    ): Session {
+    }
+
+    public function waitForSlotEvent(?int $php_flags = null)
+    {
+    }
 }

--- a/src/P11Object.php
+++ b/src/P11Object.php
@@ -1,14 +1,15 @@
 <?php
+
 namespace Pkcs11;
 
 class P11Object
 {
-	public function getAttributeValue(array $attributeIds)
-	{
-	}
+    public function getAttributeValue(array $attributeIds)
+    {
+    }
 
 
-	public function getSize()
-	{
-	}
+    public function getSize()
+    {
+    }
 }

--- a/src/RsaOaepParams.php
+++ b/src/RsaOaepParams.php
@@ -1,9 +1,10 @@
 <?php
+
 namespace Pkcs11;
 
 class RsaOaepParams
 {
-	public function __construct(int $mechanismId, int $mgfId, ?string $source = null)
-	{
-	}
+    public function __construct(int $mechanismId, int $mgfId, ?string $source = null)
+    {
+    }
 }

--- a/src/RsaPssParams.php
+++ b/src/RsaPssParams.php
@@ -1,9 +1,10 @@
 <?php
+
 namespace Pkcs11;
 
 class RsaPssParams
 {
-	public function __construct(int $mechanismId, int $mgfId, int $sLen)
-	{
-	}
+    public function __construct(int $mechanismId, int $mgfId, int $sLen)
+    {
+    }
 }

--- a/src/Salsa20Chacha20Poly1305Params.php
+++ b/src/Salsa20Chacha20Poly1305Params.php
@@ -1,9 +1,10 @@
 <?php
+
 namespace Pkcs11;
 
 class Salsa20Chacha20Poly1305Params
 {
-	public function __construct(string $nonce, string $aad)
-	{
-	}
+    public function __construct(string $nonce, string $aad)
+    {
+    }
 }

--- a/src/Salsa20Params.php
+++ b/src/Salsa20Params.php
@@ -1,9 +1,10 @@
 <?php
+
 namespace Pkcs11;
 
 class Salsa20Params
 {
-	public function __construct(string $nonce, string $blockCounter)
-	{
-	}
+    public function __construct(string $nonce, string $blockCounter)
+    {
+    }
 }

--- a/src/Session.php
+++ b/src/Session.php
@@ -1,89 +1,74 @@
 <?php
+
 namespace Pkcs11;
 
 class Session
 {
-	public function login(int $loginType, string $pin)
-	{
-	}
+    public function __debugInfo(): array
+    {
+    }
 
+    public function copyObject(P11Object $object, array $template)
+    {
+    }
 
-	public function getInfo()
-	{
-	}
+    public function createObject(array $template)
+    {
+    }
 
+    public function destroyObject(P11Object $object)
+    {
+    }
 
-	public function logout()
-	{
-	}
+    public function digest(Mechanism $mechanism, string $data)
+    {
+    }
 
+    public function findObjects(array $template): array
+    {
+    }
 
-	public function initPin(string $pin)
-	{
-	}
+    public function generateKey(Mechanism $mechanism, array $template)
+    {
+    }
 
+    public function generateKeyPair(Mechanism $mechanism, array $pkTemplate, array $skTemplate)
+    {
+    }
 
-	public function setPin(string $oldPin, string $newPin)
-	{
-	}
+    public function generateRandom(int $length): string
+    {
+    }
 
+    public function getInfo()
+    {
+    }
 
-	public function findObjects(array $template): array
-	{
-	}
+    public function initPin(string $pin)
+    {
+    }
 
+    public function initializeDigest(Mechanism $mechanism)
+    {
+    }
 
-	public function createObject(array $template)
-	{
-	}
+    public function login(int $loginType, string $pin)
+    {
+    }
 
+    public function logout()
+    {
+    }
 
-	public function copyObject(Pkcs11\P11Object $object, array $template)
-	{
-	}
+    public function openUri(string $uri)
+    {
+    }
 
+    public function seedRandom(string $seed)
+    {
+    }
 
-	public function destroyObject(Pkcs11\P11Object $object)
-	{
-	}
-
-
-	public function digest(Pkcs11\Mechanism $mechanism, string $data)
-	{
-	}
-
-
-	public function initializeDigest(Pkcs11\Mechanism $mechanism)
-	{
-	}
-
-
-	public function generateKey(Pkcs11\Mechanism $mechanism, array $template)
-	{
-	}
-
-
-	public function generateKeyPair(Pkcs11\Mechanism $mechanism, array $pkTemplate, array $skTemplate)
-	{
-	}
-
-
-	public function seedRandom(string $seed)
-	{
-	}
-
-
-	public function generateRandom(int $length): string
-	{
-	}
-
-
-	public function openUri(string $uri)
-	{
-	}
-
-
-	public function __debugInfo(): array
-	{
-	}
+    public function setPin(string $oldPin, string $newPin)
+    {
+    }
 }

--- a/src/SignatureContext.php
+++ b/src/SignatureContext.php
@@ -1,14 +1,14 @@
 <?php
+
 namespace Pkcs11;
 
 class SignatureContext
 {
-	public function update(?string $data = null): void
-	{
-	}
+    public function finalize(): string
+    {
+    }
 
-
-	public function finalize(): string
-	{
-	}
+    public function update(?string $data = null): void
+    {
+    }
 }

--- a/src/VerificationContext.php
+++ b/src/VerificationContext.php
@@ -1,14 +1,14 @@
 <?php
+
 namespace Pkcs11;
 
 class VerificationContext
 {
-	public function update(?string $data = null): void
-	{
-	}
+    public function finalize(?string $signature = null): bool
+    {
+    }
 
-
-	public function finalize(?string $signature = null): bool
-	{
-	}
+    public function update(?string $data = null): void
+    {
+    }
 }


### PR DESCRIPTION
Fixed namespaces in `Module` and `Session` classes to solve this issue:
<img width="961" alt="image" src="https://github.com/natepage/php-pkcs11-ide-helper/assets/1703419/4018b65b-9fed-4bb1-9f14-c24e707800c5">

Also:
- Fixed code style.
- Added the composer lock file.
- Updated the `.gitignore` file to exclude the `vendor` directory.